### PR TITLE
Issue/88 - 聊天室按enter後訊息送出

### DIFF
--- a/app/javascript/controllers/reset_form_controller.js
+++ b/app/javascript/controllers/reset_form_controller.js
@@ -4,4 +4,13 @@ export default class extends Controller {
   reset() {
     this.element.reset();
   }
+  onEnter(event) {
+    if (event.code === "Enter" && !event.shiftKey) {
+      if (!event.isComposing) {
+        this.element.submit();
+        event.preventDefault();
+        this.element.reset();
+      }
+    }
+  }
 }

--- a/app/views/messages/_new_message_form.html.erb
+++ b/app/views/messages/_new_message_form.html.erb
@@ -1,7 +1,7 @@
 <div class="form-group msg-form">
   <%= form_with(model: [@single_room, @message], remote: true, data: { controller: "reset-form", action: "turbo:submit-end->reset-form#reset"}) do |f| %>
   <div class="flex gap-3">
-      <%= f.text_area :body, id: 'chat-text', class: 'block w-full p-4 text-gray-900 border border-neutral-500 rounded-lg bg-neutral-400 sm:text-md focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500 w-96', autocomplete: 'off' %>
+      <%= f.text_area :body, id: 'chat-text',data:{action: "keydown->reset-form#onEnter"}, class: 'block w-full p-4 text-gray-900 border border-neutral-500 rounded-lg bg-neutral-400 sm:text-md focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500 w-96', autocomplete: 'off' %>
     <%= f.submit data: {disable_with: false}, class: 'px-5 py-3 text-sm font-medium text-center text-white bg-blue-700 rounded-lg cursor-pointer hover:bg-blue-800 focus:ring-4 focus:ring-blue-300 dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800' %>
   </div>
 <% end %>


### PR DESCRIPTION
According to issue https://github.com/astrocamp/15th-SyncSquad/issues/88


1. 中文輸入法 第一次Enter是確定選字 第二次Enter是真正送出

https://github.com/astrocamp/15th-SyncSquad/assets/145585863/184b53bd-2da7-4b3d-b058-dc95f2011274


Note:
還在選字時，IsComposing為false:
<img width="351" alt="Screenshot 0006-01-08 at 10 40 55 PM" src="https://github.com/astrocamp/15th-SyncSquad/assets/145585863/07c6135f-e951-4670-9595-efe150133dc9">

沒選字，已確定正確的字時，IsComposing為true:
<img width="346" alt="Screenshot 0006-01-08 at 10 41 15 PM" src="https://github.com/astrocamp/15th-SyncSquad/assets/145585863/5cab4d01-f4a1-4874-9611-7056ea114e91">


2. 英文輸入法 Enter即送出


https://github.com/astrocamp/15th-SyncSquad/assets/145585863/2fd6f848-e6ce-4a59-961e-88290538f52c



3. 按下Shift + Enter 換行，不送出訊息

https://github.com/astrocamp/15th-SyncSquad/assets/145585863/6037451b-7382-4995-887e-f1f8184ab891

